### PR TITLE
Add .NET 9 Web API with auth and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/AppService.Tests/AppService.Tests.csproj
+++ b/AppService.Tests/AppService.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AppService\AppService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AppService.Tests/UserServiceTests.cs
+++ b/AppService.Tests/UserServiceTests.cs
@@ -1,0 +1,51 @@
+using AppService.Services;
+using Xunit;
+
+namespace AppService.Tests;
+
+public class UserServiceTests
+{
+    [Fact]
+    public async Task Register_New_User_Succeeds()
+    {
+        var service = new UserService();
+        var user = await service.RegisterAsync("alice", "password");
+        Assert.Equal("alice", user.UserName);
+        Assert.True(await service.UserExistsAsync("alice"));
+    }
+
+    [Fact]
+    public async Task Register_Duplicate_User_Throws()
+    {
+        var service = new UserService();
+        await service.RegisterAsync("alice", "password");
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.RegisterAsync("alice", "password"));
+    }
+
+    [Fact]
+    public async Task Login_With_Correct_Credentials_Returns_User()
+    {
+        var service = new UserService();
+        await service.RegisterAsync("alice", "password");
+        var user = await service.LoginAsync("alice", "password");
+        Assert.NotNull(user);
+        Assert.Equal("alice", user!.UserName);
+    }
+
+    [Fact]
+    public async Task Login_With_Wrong_Password_Returns_Null()
+    {
+        var service = new UserService();
+        await service.RegisterAsync("alice", "password");
+        var user = await service.LoginAsync("alice", "wrong");
+        Assert.Null(user);
+    }
+
+    [Fact]
+    public async Task Login_With_Unknown_User_Returns_Null()
+    {
+        var service = new UserService();
+        var user = await service.LoginAsync("bob", "password");
+        Assert.Null(user);
+    }
+}

--- a/AppService.sln
+++ b/AppService.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppService", "AppService\AppService.csproj", "{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppService.Tests", "AppService.Tests\AppService.Tests.csproj", "{A653BBC3-4FE3-499F-ACB4-630C96744D52}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Debug|x86.Build.0 = Debug|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|x64.Build.0 = Release|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBE3A5BA-3404-4B49-90DF-A53213EA0EB9}.Release|x86.Build.0 = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|x64.Build.0 = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Debug|x86.Build.0 = Debug|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|x64.ActiveCfg = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|x64.Build.0 = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|x86.ActiveCfg = Release|Any CPU
+		{A653BBC3-4FE3-499F-ACB4-630C96744D52}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/AppService/AppService.csproj
+++ b/AppService/AppService.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/AppService/AppService.http
+++ b/AppService/AppService.http
@@ -1,0 +1,6 @@
+@AppService_HostAddress = http://localhost:5153
+
+GET {{AppService_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/AppService/Models/LoginRequest.cs
+++ b/AppService/Models/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace AppService.Models;
+
+public record LoginRequest(string UserName, string Password);

--- a/AppService/Models/RegisterRequest.cs
+++ b/AppService/Models/RegisterRequest.cs
@@ -1,0 +1,3 @@
+namespace AppService.Models;
+
+public record RegisterRequest(string UserName, string Password);

--- a/AppService/Models/User.cs
+++ b/AppService/Models/User.cs
@@ -1,0 +1,8 @@
+namespace AppService.Models;
+
+public class User
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string UserName { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+}

--- a/AppService/Program.cs
+++ b/AppService/Program.cs
@@ -1,0 +1,62 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+builder.Services.AddSingleton<AppService.Services.IUserService, AppService.Services.UserService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.MapPost("/register", async (AppService.Models.RegisterRequest req, AppService.Services.IUserService userService) =>
+{
+    if (await userService.UserExistsAsync(req.UserName))
+    {
+        return Results.BadRequest("User already exists");
+    }
+    var user = await userService.RegisterAsync(req.UserName, req.Password);
+    return Results.Ok(new { user.Id, user.UserName });
+}).WithName("Register");
+
+app.MapPost("/login", async (AppService.Models.LoginRequest req, AppService.Services.IUserService userService) =>
+{
+    var user = await userService.LoginAsync(req.UserName, req.Password);
+    if (user is null)
+    {
+        return Results.Unauthorized();
+    }
+    return Results.Ok(new { user.Id, user.UserName });
+}).WithName("Login");
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast");
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/AppService/Properties/launchSettings.json
+++ b/AppService/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5153",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7174;http://localhost:5153",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/AppService/Services/IUserService.cs
+++ b/AppService/Services/IUserService.cs
@@ -1,0 +1,10 @@
+using AppService.Models;
+
+namespace AppService.Services;
+
+public interface IUserService
+{
+    Task<User> RegisterAsync(string userName, string password);
+    Task<User?> LoginAsync(string userName, string password);
+    Task<bool> UserExistsAsync(string userName);
+}

--- a/AppService/Services/UserService.cs
+++ b/AppService/Services/UserService.cs
@@ -1,0 +1,36 @@
+using AppService.Models;
+using Microsoft.AspNetCore.Identity;
+
+namespace AppService.Services;
+
+public class UserService : IUserService
+{
+    private readonly List<User> _users = new();
+    private readonly PasswordHasher<User> _hasher = new();
+
+    public Task<bool> UserExistsAsync(string userName)
+    {
+        return Task.FromResult(_users.Any(u => u.UserName.Equals(userName, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    public async Task<User> RegisterAsync(string userName, string password)
+    {
+        if (await UserExistsAsync(userName))
+        {
+            throw new InvalidOperationException("User already exists");
+        }
+
+        var user = new User { UserName = userName };
+        user.PasswordHash = _hasher.HashPassword(user, password);
+        _users.Add(user);
+        return user;
+    }
+
+    public Task<User?> LoginAsync(string userName, string password)
+    {
+        var user = _users.FirstOrDefault(u => u.UserName.Equals(userName, StringComparison.OrdinalIgnoreCase));
+        if (user == null) return Task.FromResult<User?>(null);
+        var result = _hasher.VerifyHashedPassword(user, user.PasswordHash, password);
+        return Task.FromResult(result == PasswordVerificationResult.Success ? user : null);
+    }
+}

--- a/AppService/appsettings.Development.json
+++ b/AppService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/AppService/appsettings.json
+++ b/AppService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- create .NET 9 solution with Web API project and test project
- implement in-memory user service
- add registration and login endpoints
- test all user service scenarios

## Testing
- `dotnet test AppService.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68408fee33ec8328be034b04b0679a33